### PR TITLE
feat: complete dashboard with Spotify profile integration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.fbcdn.net",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -8,14 +8,7 @@ import type { AdapterUser } from "next-auth/adapters";
 import { PrismaClient } from "@prisma/client";
 import SpotifyProvider from "next-auth/providers/spotify";
 import { refreshSpotifyToken } from "@/lib/spotify";
-
-interface CustomJWT {
-  accessToken?: string;
-  refreshToken?: string;
-  expiresAt?: number;
-  spotifyId?: string;
-  error?: string;
-}
+import { CustomJWT } from "@/types/auth";
 
 // create new prisma client instance to communciate with our database
 const prisma = new PrismaClient();

--- a/src/app/api/spotify-profile/route.ts
+++ b/src/app/api/spotify-profile/route.ts
@@ -1,0 +1,28 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+import { fetchSpotifyUserProfile } from "@/lib/spotifyApi";
+import { ExtendedSession } from "@/types/auth";
+import { Session } from "next-auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const extendedSession = session as Session & ExtendedSession;
+
+  if (!extendedSession.spotifyId) {
+    return Response.json({ error: "No Spotify ID" }, { status: 400 });
+  }
+
+  try {
+    const userProfile = await fetchSpotifyUserProfile(
+      extendedSession.spotifyId
+    );
+    return Response.json({ userProfile });
+  } catch {
+    return Response.json({ error: "Failed to fetch profile" }, { status: 500 });
+  }
+}

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,12 +1,7 @@
 import { getServerSession, Session } from "next-auth";
 import { PrismaClient } from "@prisma/client";
 import { authOptions } from "../auth/[...nextauth]/route";
-
-interface ExtendedSession {
-  spotifyId?: string;
-  accessToken?: string;
-  refreshToken?: string;
-}
+import { ExtendedSession } from "@/types/auth";
 
 const prisma = new PrismaClient();
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,55 @@
+"use client";
 import Footer from "@/components/Footer";
 import Main from "@/components/Main";
+import { useSession } from "next-auth/react";
+import { Session } from "next-auth";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { SpotifyUserProfile } from "@/types/spotify";
+import { ExtendedSession } from "@/types/auth";
 
 const DashBoard = () => {
+  const [userProfile, setUserProfile] = useState<SpotifyUserProfile | null>(
+    null
+  );
+  const { data: session } = useSession();
+  const router = useRouter();
+
+  //client side auth check
+  useEffect(() => {
+    const fetchUserData = async () => {
+      if (!session) {
+        router.push("/");
+        return;
+      }
+
+      //if we have session, get user data
+      //TypeScript type casting: "This session has both default + our custom Spotify properties
+      const extendedSession = session as Session & ExtendedSession;
+      const spotifyId = extendedSession.spotifyId;
+
+      if (spotifyId) {
+        try {
+          const userData = await fetch("/api/spotify-profile");
+          const result = await userData.json();
+
+          setUserProfile(result.userProfile);
+        } catch (error) {
+          console.error("Error fetching user data:", error);
+        }
+      }
+    };
+    fetchUserData();
+  }, [session, router]);
+
+  //dont render anything until we have a session
+  if (!session) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div>
-      <Main />
+      <Main userProfile={userProfile} />
 
       <Footer />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,46 +1,45 @@
 "use client";
 
-import { useSession, signIn, signOut } from "next-auth/react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Music } from "lucide-react";
+import { signIn } from "next-auth/react";
 
 export default function Home() {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
+  const router = useRouter();
 
-  //loading state
-  if (status === "loading") {
-    return <main className="text-white text-xl p-4">Loading...</main>;
-  }
+  // Send logged-in users to dashboard
+  useEffect(() => {
+    if (session) {
+      router.push("/dashboard");
+    }
+  }, [session, router]);
 
+  // Show login card for non-logged-in users
   return (
-    <main>
-      <h1>NextGen Music Player</h1>
-
-      {/* show different content based on login status */}
-
-      {session ? (
-        //user is logged in
-        <div>
-          <p>Welcome, {session.user?.name}!</p>
-
-          <button
-            onClick={() => signOut()}
-            className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
-          >
-            Logout
-          </button>
-        </div>
-      ) : (
-        // user is not logged in
-        <div>
-          <p>Please log in to access your music</p>
-
-          <button
-            onClick={() => signIn()}
-            className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
-          >
-            Login
-          </button>
-        </div>
-      )}
-    </main>
+    <div className="flex items-center justify-center min-h-screen">
+      <Card className="w-[400px]">
+        <CardHeader>
+          <CardTitle>Welcome to NextGen Music</CardTitle>
+          <CardDescription>Login with your Spotify account</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={() => signIn()}>
+            <Music className="mr-2 h-4 w-4" />
+            Login with Spotify
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,20 +1,96 @@
+"use client";
+
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
   SidebarHeader,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
 } from "@/components/ui/sidebar";
 
+import { Home, ListMusic, Search, User } from "lucide-react";
+import { signOut } from "next-auth/react";
+import { Button } from "./ui/button";
+import { useSession } from "next-auth/react";
+import NextImage from "next/image";
+
+const sidebarMenuItems = [
+  {
+    title: "Home",
+    url: "/dashboard",
+    icon: Home,
+  },
+  {
+    title: "Playlists",
+    url: "/playlists",
+    icon: ListMusic,
+  },
+  {
+    title: "Search",
+    url: "/search",
+    icon: Search,
+  },
+  {
+    title: "Profile",
+    url: "/profile",
+    icon: User,
+  },
+];
+
 export function AppSidebar() {
+  const { data: session } = useSession();
+
   return (
     <Sidebar>
       <SidebarHeader />
       <SidebarContent>
         <SidebarGroup />
+        <SidebarGroupLabel>Menu</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {sidebarMenuItems.map((item) => (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild>
+                  <a href={item.url}>
+                    <item.icon />
+                    <span>{item.title}</span>
+                  </a>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
         <SidebarGroup />
       </SidebarContent>
-      <SidebarFooter />
+      <SidebarFooter className="border-t pt-2">
+        {session?.user && (
+          <div className="flex items-center gap-3 p-2 rounded-md bg-gray-50">
+            <NextImage
+              src={session.user.image || "/default-avatar.png"}
+              alt="User avatar"
+              width={40}
+              height={40}
+              className="rounded-full"
+            />
+            <div className="flex-1 text-sm">
+              <div className="font-medium">{session.user.name}</div>
+              <div className="text-gray-500">{session.user.email}</div>
+            </div>
+          </div>
+        )}
+        <Button
+          onClick={() => signOut()}
+          variant="outline"
+          className="w-full mt-2"
+        >
+          Logout
+        </Button>
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,5 +1,22 @@
-const Main = () => {
-  return <div>Main</div>;
+import { SpotifyUserProfile } from "@/types/spotify";
+
+interface MainProps {
+  userProfile: SpotifyUserProfile | null;
+}
+
+const Main = ({ userProfile }: MainProps) => {
+  if (!userProfile) {
+    return <div>Loading user data...</div>;
+  }
+
+  return (
+    <main className="p-4">
+      <h1>Welcome, {userProfile.display_name}</h1>
+      <p>Follwers: {userProfile.followers.total}</p>
+      <p>Email: {userProfile.email}</p>
+      {/* add more info here */}
+    </main>
+  );
 };
 
 export default Main;

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,13 @@
+export interface ExtendedSession {
+  spotifyId?: string;
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+export interface CustomJWT {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  spotifyId?: string;
+  error?: string;
+}

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -1,0 +1,12 @@
+export interface SpotifyUserProfile {
+  display_name: string;
+  followers: {
+    total: number;
+  };
+  email: string;
+  images: Array<{
+    url: string;
+    height: number;
+    width: number;
+  }>;
+}


### PR DESCRIPTION
- Implement protected dashboard routes with client-side auth
- Create professional sidebar with user avatar, name, email, and logout
- Build dedicated login page with ShadCN Card components
- Add Spotify profile API integration with proper client/server separation
- Create API bridge route to handle Prisma database calls from client
- Display real user data (name, followers, email) in dashboard
- Organize TypeScript interfaces in shared types folder
- Add proper error handling and loading states throughout

Dashboard now shows authenticated user's Spotify profile data.