### PR TITLE
feat: implement beautiful card layouts for Spotify music data display

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,14 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "**.fbcdn.net",
       },
+      {
+        protocol: "https",
+        hostname: "**.scdn.co",
+      },
+      {
+        protocol: "https",
+        hostname: "**.spotifycdn.com",
+      },
     ],
   },
 };

--- a/src/components/PlaylistCard.tsx
+++ b/src/components/PlaylistCard.tsx
@@ -1,0 +1,50 @@
+import { Card, CardContent } from "./ui/card";
+import { SpotifyPlaylist } from "@/types/spotify";
+import Image from "next/image";
+
+interface PlaylistCardProps {
+  playlist: SpotifyPlaylist;
+}
+
+const PlaylistCard = ({ playlist }: PlaylistCardProps) => {
+  const imageUrl =
+    playlist.images && playlist.images.length > 0
+      ? playlist.images[0].url
+      : null;
+
+  return (
+    <Card className="mb-4">
+      <CardContent className="flex items-center p-4">
+        {/* Image on left */}
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={playlist.name}
+            className="rounded-md mr-4 object-cover"
+            width={64}
+            height={64}
+          />
+        ) : (
+          <div className="w-16 h-16 bg-gray-300 rounded-md mr-4 flex items-center justify-center">
+            <span className="text-gray-500 text-xs">No Image</span>
+          </div>
+        )}
+
+        {/* text on right */}
+        <div className="flex-1">
+          <h3 className="font-semibold text-lg">{playlist.name}</h3>
+          <p className="text-sm text-gray-600">
+            {playlist.tracks.total} tracks
+          </p>
+          {playlist.description && (
+            <p className="text-sm text-gray-500 mt-1 line-clamp-2">
+              {playlist.description}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PlaylistCard;

--- a/src/components/Playlists.tsx
+++ b/src/components/Playlists.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { SpotifyPlaylist } from "@/types/spotify";
+import PlaylistCard from "./PlaylistCard";
 
 const Playlists = () => {
   const [playlists, setPlaylists] = useState<SpotifyPlaylist[] | null>(null);
@@ -28,10 +29,16 @@ const Playlists = () => {
 
   return (
     <div>
-      <h2>Your Playlists</h2>
-      {playlists && Array.isArray(playlists)
-        ? `Found ${playlists.length} playlists!`
-        : "No playlists"}
+      <h2 className="text-center p-10">Your Playlists</h2>
+      {playlists && Array.isArray(playlists) ? (
+        <div className="grid grid-cols-3 gap-4">
+          {playlists.slice(0, 6).map((playlist) => (
+            <PlaylistCard key={playlist.id} playlist={playlist} />
+          ))}
+        </div>
+      ) : (
+        "No playlists found"
+      )}
     </div>
   );
 };

--- a/src/components/TopTracks.tsx
+++ b/src/components/TopTracks.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { SpotifyTrack } from "@/types/spotify";
+import TrackCard from "./TrackCard";
 
 const TopTracks = () => {
   const [topTracks, setTopTracks] = useState<SpotifyTrack[] | null>(null);
@@ -28,10 +29,16 @@ const TopTracks = () => {
 
   return (
     <div>
-      <h2>Your Top Tracks</h2>
-      {topTracks && Array.isArray(topTracks)
-        ? `Found ${topTracks.length} top tracks!`
-        : "No tracks found"}
+      <h2 className="text-center p-10">Your Top Tracks</h2>
+      {topTracks && Array.isArray(topTracks) ? (
+        <div className="grid grid-cols-3 gap-4">
+          {topTracks.slice(0, 6).map((track) => (
+            <TrackCard key={track.id} track={track} />
+          ))}
+        </div>
+      ) : (
+        "No tracks found"
+      )}
     </div>
   );
 };

--- a/src/components/TrackCard.tsx
+++ b/src/components/TrackCard.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent } from "./ui/card";
+import { SpotifyTrack } from "@/types/spotify";
+import Image from "next/image";
+
+interface TrackCardProps {
+  track: SpotifyTrack;
+}
+const TrackCard = ({ track }: TrackCardProps) => {
+  //get album artwork
+  const imageUrl =
+    track.album.images && track.album.images.length > 0
+      ? track.album.images[0].url
+      : null;
+
+  //convert from miliseconds
+  const formatDuration = (ms: number) => {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  };
+
+  //join multiple artists names
+  const artistNames = track.artists.map((artist) => artist.name).join(", ");
+
+  return (
+    <Card className="mb-4">
+      <CardContent className="flex items-center p-4">
+        {/* Album artwork */}
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={track.album.name}
+            className="rounded-md mr-4 object-cover"
+            width={64}
+            height={64}
+          />
+        ) : (
+          <div className="w-16 h-16 bg-gray-300 rounded-md mr-4 flex items-center justify-center">
+            <span className="text-gray-500 text-xs">No Image</span>
+          </div>
+        )}
+
+        {/* Track info */}
+        <div className="flex-1">
+          <h3 className="font-semibold text-lg">{track.name}</h3>
+          <p className="text-sm text-gray-600">{artistNames}</p>
+          <p className="text-sm text-gray-500">
+            {formatDuration(track.duration_ms)}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TrackCard;


### PR DESCRIPTION
- Create PlaylistCard and TrackCard components with ShadCN Card styling
- Display playlist covers, names, track counts, and descriptions in grid layout
- Show top track album art, names, artists, and formatted durations
- Add proper image fallbacks for missing playlist/album artwork
- Configure Next.js Image optimization for Spotify CDN domains
- Center section titles and implement responsive grid layouts
- Replace basic data counts with rich visual music cards