### PR TITLE
feat: implement Spotify Web Player with complete playback controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-separator": "^1.1.7",
+        "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
         "class-variance-authority": "^0.7.1",
@@ -1049,6 +1050,11 @@
         "@prisma/debug": "6.12.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -1642,6 +1648,43 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
@@ -7651,6 +7694,11 @@
         "@prisma/debug": "6.12.0"
       }
     },
+    "@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
+    },
     "@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -7950,6 +7998,31 @@
       "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
       "requires": {
         "@radix-ui/react-primitive": "2.1.3"
+      }
+    },
+    "@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "requires": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "dependencies": {
+        "@radix-ui/primitive": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+          "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+        }
       }
     },
     "@radix-ui/react-slot": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-separator": "^1.1.7",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
     "class-variance-authority": "^0.7.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Providers } from "./providers";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
 import { Toaster } from "sonner";
+import GlobalPlayer from "@/components/GlobalPlayer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,6 +39,7 @@ export default function RootLayout({
               <SidebarTrigger />
               {children}
             </main>
+            <GlobalPlayer />
           </SidebarProvider>
         </Providers>
         <Toaster />

--- a/src/components/GlobalPlayer.tsx
+++ b/src/components/GlobalPlayer.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import WebPlaybackPlayer from "./WebPlaybackPlayer";
+
+const GlobalPlayer = () => {
+  return <WebPlaybackPlayer />;
+};
+
+export default GlobalPlayer;

--- a/src/components/MiniPlayer.tsx
+++ b/src/components/MiniPlayer.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { MiniPlayerProps } from "@/types/spotify";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Play, Pause, SkipBack, SkipForward, Volume2 } from "lucide-react";
+import Image from "next/image";
+
+const MiniPlayer = ({
+  currentTrack,
+  isPlaying,
+  position,
+  duration,
+  onPlay,
+  onPause,
+  onNext,
+  onPrevious,
+  handleSeek,
+  volume,
+  handleVolumeChange,
+}: MiniPlayerProps) => {
+  // Format time in mm:ss format
+  const formatTime = (ms: number) => {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  };
+
+  // Calculate progress percentage
+  const progressPercentage = duration > 0 ? (position / duration) * 100 : 0;
+
+  const onSeekChange = (value: number[]) => {
+    handleSeek(value[0]);
+  };
+
+  const onVolumeChange = (value: number[]) => {
+    handleVolumeChange(value[0]);
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-white border-t p-4">
+      <div className="max-w-screen-xl mx-auto">
+        {/* Progress bar - spans full width */}
+        {currentTrack && (
+          <div className="mb-3">
+            <div className="flex items-center space-x-2 text-xs text-gray-500 mb-1">
+              <span>{formatTime(position)}</span>
+              <div className="flex-1">
+                <Slider
+                  value={[progressPercentage]}
+                  max={100}
+                  step={0.1}
+                  onValueChange={onSeekChange}
+                  className="w-full"
+                />
+              </div>
+              <span>{formatTime(duration)}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Main player controls */}
+        <div className="flex items-center justify-between">
+          {/* Track info section */}
+          <div className="flex items-center space-x-3 flex-1">
+            {currentTrack ? (
+              <>
+                {/* Album artwork */}
+                <div className="w-12 h-12 bg-gray-300 rounded overflow-hidden relative">
+                  {currentTrack.album.images?.[0] && (
+                    <Image
+                      src={currentTrack.album.images[0].url}
+                      alt={currentTrack.album.name}
+                      width={48}
+                      height={48}
+                      className="object-cover"
+                    />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium truncate">{currentTrack.name}</p>
+                  <p className="text-sm text-gray-600 truncate">
+                    {currentTrack.artists
+                      .map((artist) => artist.name)
+                      .join(", ")}
+                  </p>
+                </div>
+              </>
+            ) : (
+              <p className="text-gray-500">No track playing</p>
+            )}
+          </div>
+
+          {/* Controls section */}
+          <div className="flex items-center space-x-2 mx-8">
+            <Button variant="outline" size="sm" onClick={onPrevious}>
+              <SkipBack className="h-4 w-4" />
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={isPlaying ? onPause : onPlay}
+            >
+              {isPlaying ? (
+                <Pause className="h-4 w-4" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+            </Button>
+
+            <Button variant="outline" size="sm" onClick={onNext}>
+              <SkipForward className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {/* Volume section */}
+          <div className="flex items-center space-x-2 flex-1 justify-end">
+            <Volume2 className="h-4 w-4 text-gray-600" />
+            <div className="w-24">
+              <Slider
+                value={[volume]}
+                max={100}
+                step={1}
+                onValueChange={onVolumeChange}
+                className="w-full"
+              />
+            </div>
+            <span className="text-xs text-gray-500 w-8 text-right">
+              {Math.round(volume)}%
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MiniPlayer;

--- a/src/components/WebPlaybackPlayer.tsx
+++ b/src/components/WebPlaybackPlayer.tsx
@@ -4,7 +4,12 @@ import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { ExtendedSession } from "@/types/auth";
 import "@/types/spotify";
-import { SpotifyPlayer } from "@/types/spotify";
+import {
+  SpotifyPlayer,
+  SpotifyPlayerState,
+  SpotifyTrack,
+} from "@/types/spotify";
+import MiniPlayer from "./MiniPlayer";
 
 const WebPlaybackPlayer = () => {
   const { data: session } = useSession();
@@ -13,13 +18,36 @@ const WebPlaybackPlayer = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [sdkLoaded, setSdkLoaded] = useState(false);
   const [player, setPlayer] = useState<SpotifyPlayer | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTrack, setCurrentTrack] = useState<SpotifyTrack | null>(null);
+  const [position, setPosition] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(50);
+
+  const handlePlay = () => player?.resume();
+  const handlePause = () => player?.pause();
+  const handleNext = () => player?.nextTrack();
+  const handlePrevious = () => player?.previousTrack();
+
+  const handleSeek = (percentage: number) => {
+    if (player && duration > 0) {
+      const newPosition = (percentage / 100) * duration;
+      player.seek(newPosition);
+    }
+  };
+
+  const handleVolumeChange = (percentage: number) => {
+    if (player) {
+      const volumeLevel = percentage / 100;
+      player.setVolume(volumeLevel);
+      setVolume(percentage);
+    }
+  };
 
   useEffect(() => {
     const loadSpotifySDK = () => {
-      //cast session to include our custom spotify props
       const extendedSession = session as ExtendedSession;
 
-      //only proceed if we have a session with access token
       if (!extendedSession.accessToken) {
         console.error("No access token available");
         return;
@@ -27,7 +55,6 @@ const WebPlaybackPlayer = () => {
 
       const accessToken = extendedSession.accessToken;
 
-      // Check if script already exists
       if (document.querySelector('script[src*="spotify-player"]')) {
         setSdkLoaded(true);
         return;
@@ -38,8 +65,6 @@ const WebPlaybackPlayer = () => {
       script.async = true;
 
       window.onSpotifyWebPlaybackSDKReady = () => {
-        console.log("Spotify SDK is ready");
-
         const player = new window.Spotify!.Player({
           name: "My Web Player",
           getOAuthToken: (cb) => {
@@ -47,17 +72,31 @@ const WebPlaybackPlayer = () => {
           },
         });
 
-        //connect player
         player.connect();
 
         player.addListener("ready", (data) => {
           const { device_id } = data as { device_id: string };
           console.log("Ready with Device ID", device_id);
+
+          // Get initial volume
+          player.getVolume().then((volume) => {
+            setVolume(volume * 100);
+          });
         });
 
         player.addListener("not_ready", (data) => {
           const { device_id } = data as { device_id: string };
           console.log("Device ID has gone offline", device_id);
+        });
+
+        player.addListener("player_state_changed", (data) => {
+          const state = data as SpotifyPlayerState | null;
+          if (state) {
+            setIsPlaying(!state.paused);
+            setCurrentTrack(state.track_window.current_track);
+            setPosition(state.position);
+            setDuration(state.track_window.current_track.duration_ms);
+          }
         });
 
         setPlayer(player);
@@ -67,24 +106,18 @@ const WebPlaybackPlayer = () => {
       document.head.appendChild(script);
     };
 
-    //CHECK STATUS FUNCTION
     const checkPremiumStatus = async () => {
-      //only proceed if user is logged in
       if (!session) {
         setIsLoading(false);
         return;
       }
 
       try {
-        //call API route
         const response = await fetch("/api/user/premium-status");
-        //parse data
         const premiumStatusData = await response.json();
 
-        //update state with result
         setIsPremium(premiumStatusData.isPremium);
 
-        //if user is premium, load the SDK
         if (premiumStatusData.isPremium) {
           loadSpotifySDK();
         }
@@ -102,15 +135,29 @@ const WebPlaybackPlayer = () => {
     return <div>Checking subscription status...</div>;
   }
 
-  //mesage for non-premium users
   if (!isPremium) {
     return <div>Spotify Premium required for playback</div>;
   }
 
   return (
     <div>
-      <h2>Spotify Web Player</h2>
-      <p>Premium user detected - Ready to load SDK</p>
+      {!sdkLoaded ? (
+        <p>Loading player...</p>
+      ) : (
+        <MiniPlayer
+          currentTrack={currentTrack}
+          isPlaying={isPlaying}
+          position={position}
+          duration={duration}
+          onPlay={handlePlay}
+          onPause={handlePause}
+          onNext={handleNext}
+          onPrevious={handlePrevious}
+          handleSeek={handleSeek}
+          volume={volume}
+          handleVolumeChange={handleVolumeChange}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -178,3 +178,17 @@ declare global {
     };
   }
 }
+
+export interface MiniPlayerProps {
+  currentTrack: SpotifyTrack | null;
+  isPlaying: boolean;
+  position: number;
+  duration: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  handleSeek: (percentage: number) => void;
+  volume: number;
+  handleVolumeChange: (percentage: number) => void;
+}


### PR DESCRIPTION
- Add WebPlaybackPlayer component with Spotify Web Playback SDK integration
- Add MiniPlayer component with play/pause/skip/volume controls
- Implement real-time track state management and player event listeners
- Add progress bar with seeking functionality and time display
- Add volume control slider with percentage display and real-time adjustment
- Display current track info with album artwork using Next.js Image optimization
- Connect all controls to Spotify player methods (resume, pause, nextTrack, previousTrack, seek, setVolume)
- Add proper TypeScript interfaces for player state and component props
- Position MiniPlayer as fixed bottom component visible across all pages
- Remove debug console logs and clean up button event handlers

Premium users can now control Spotify playback directly from the web app with full media controls and track information display.