### PR TITLE
fix: resolve navigation playback persistence and add direct track pla…

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import {
   Sidebar,
   SidebarContent,
@@ -56,10 +57,10 @@ export function AppSidebar() {
             {sidebarMenuItems.map((item) => (
               <SidebarMenuItem key={item.title}>
                 <SidebarMenuButton asChild>
-                  <a href={item.url}>
+                  <Link href={item.url}>
                     <item.icon />
                     <span>{item.title}</span>
-                  </a>
+                  </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ))}

--- a/src/components/TrackInfo.tsx
+++ b/src/components/TrackInfo.tsx
@@ -172,11 +172,6 @@ const TrackInfo = ({
       return;
     }
 
-    // Add these debug logs
-    console.log("Track object:", track);
-    console.log("Track URI:", track.uri);
-    console.log("Device ID:", deviceId);
-
     try {
       const response = await fetch("/api/spotify/play", {
         method: "PUT",

--- a/src/lib/spotifyPlayerManager.js
+++ b/src/lib/spotifyPlayerManager.js
@@ -1,0 +1,107 @@
+class SpotifyPlayerManager {
+  constructor() {
+    this.player = null; // Spotify SDK player instance
+    this.deviceId = null; // Unique device identifier from Spotify
+    this.isInitialized = false; // Prevent multiple initializations
+    this.stateUpdateCallback = null; // Callback to update React state
+  }
+
+  /**
+   * Sets the callback function that will receive player state updates
+   * This is how we communicate player changes back to React components
+   */
+  setStateUpdateCallback(callback) {
+    this.stateUpdateCallback = callback;
+  }
+
+  /**
+   * Sends state updates to React components through the callback
+   * This bridges the gap between the external player and React state
+   */
+  updateState(stateData) {
+    if (this.stateUpdateCallback) {
+      this.stateUpdateCallback(stateData);
+    }
+  }
+
+  /**
+   * Initialize the Spotify Web Player (called only once per session)
+   * Loads the SDK, creates the player, and sets up event listeners
+   */
+  async initialize(accessToken) {
+    // Prevent multiple initializations
+    if (this.isInitialized) {
+      return;
+    }
+
+    // Load the Spotify SDK script if not already present
+    if (!document.querySelector('script[src*="spotify-player"]')) {
+      const script = document.createElement("script");
+      script.src = "https://sdk.scdn.co/spotify-player.js";
+      script.async = true;
+      document.head.appendChild(script);
+    }
+
+    // Wait for SDK to load and initialize player
+    return new Promise((resolve) => {
+      window.onSpotifyWebPlaybackSDKReady = () => {
+        // Create the Spotify player instance
+        this.player = new window.Spotify.Player({
+          name: "NextGen Music Player",
+          getOAuthToken: (cb) => {
+            cb(accessToken);
+          },
+        });
+
+        // Connect to Spotify's servers
+        this.player.connect();
+
+        // Handle when player is ready and we get our device ID
+        this.player.addListener("ready", (data) => {
+          this.deviceId = data.device_id;
+
+          // Notify React that the device is ready
+          this.updateState({
+            type: "DEVICE_READY",
+            deviceId: this.deviceId,
+          });
+
+          resolve();
+        });
+
+        // Handle playback state changes (play/pause/track changes)
+        this.player.addListener("player_state_changed", (data) => {
+          if (data) {
+            // Send current playback state to React
+            this.updateState({
+              type: "PLAYBACK_STATE",
+              isPlaying: !data.paused,
+              currentTrack: data.track_window?.current_track,
+              position: data.position,
+              duration: data.track_window?.current_track?.duration_ms,
+            });
+          }
+        });
+
+        this.isInitialized = true;
+      };
+    });
+  }
+
+  /**
+   * Clean up the player when no longer needed
+   */
+  disconnect() {
+    if (this.player) {
+      this.player.disconnect();
+      this.player = null;
+      this.deviceId = null;
+      this.isInitialized = false;
+    }
+  }
+}
+
+// Export a single global instance (singleton pattern)
+// This ensures the same player persists across all components
+const spotifyPlayerManager = new SpotifyPlayerManager();
+export default spotifyPlayerManager;

--- a/src/lib/stores/playerStore.ts
+++ b/src/lib/stores/playerStore.ts
@@ -23,6 +23,10 @@ interface PlayerState {
   setPosition: (position: number) => void;
   setDuration: (duration: number) => void;
   setVolume: (volume: number) => void;
+  handleExternalUpdate: (update: {
+    type: string;
+    [key: string]: unknown;
+  }) => void;
 }
 
 export const usePlayerStore = create<PlayerState>((set) => ({
@@ -45,4 +49,19 @@ export const usePlayerStore = create<PlayerState>((set) => ({
   setPosition: (position) => set({ position }),
   setDuration: (duration) => set({ duration }),
   setVolume: (volume) => set({ volume }),
+  handleExternalUpdate: (update: { type: string; [key: string]: unknown }) => {
+    if (update.type === "DEVICE_READY") {
+      if (typeof update.deviceId === "string") {
+        set({ deviceId: update.deviceId });
+      }
+    } else if (update.type === "PLAYBACK_STATE") {
+      set({
+        isPlaying:
+          typeof update.isPlaying === "boolean" ? update.isPlaying : false,
+        currentTrack: update.currentTrack as SpotifyTrack | null,
+        position: typeof update.position === "number" ? update.position : 0,
+        duration: typeof update.duration === "number" ? update.duration : 0,
+      });
+    }
+  },
 }));


### PR DESCRIPTION
…yback

- Fix critical navigation bug where <a href> tags caused full page refreshes
- Replace HTML anchor tags with Next.js Link components for client-side routing
- Implement external SpotifyPlayerManager singleton outside React lifecycle
- Add Zustand store for global player state management across components
- Create API routes for direct track playback without external Spotify app
- Add play buttons to search results, liked tracks, and playlist components
- Implement device targeting and automatic playback transfer
- Clean up TypeScript types and remove debug console logs

Breaking change: Music now persists seamlessly across all navigation
New feature: Users can start playback directly from any track listing