### PR TITLE
feat: implement queue system for music player controls

### DIFF
--- a/src/components/TopTracks.tsx
+++ b/src/components/TopTracks.tsx
@@ -32,8 +32,14 @@ const TopTracks = () => {
       <h2 className="text-center p-10">Your Top Tracks</h2>
       {topTracks && Array.isArray(topTracks) ? (
         <div className="grid grid-cols-3 gap-4">
-          {topTracks.slice(0, 6).map((track) => (
-            <TrackCard key={track.id} track={track} />
+          {topTracks.slice(0, 6).map((track, index) => (
+            <TrackCard
+              key={track.id}
+              track={track}
+              allTracks={topTracks.slice(0, 6)}
+              trackIndex={index}
+              playbackContext="dashboard"
+            />
           ))}
         </div>
       ) : (

--- a/src/components/WebPlaybackPlayer.tsx
+++ b/src/components/WebPlaybackPlayer.tsx
@@ -67,8 +67,65 @@ const WebPlaybackPlayer = () => {
   // Player control handlers
   const handlePlay = () => spotifyPlayerManager.player?.resume();
   const handlePause = () => spotifyPlayerManager.player?.pause();
-  const handleNext = () => spotifyPlayerManager.player?.nextTrack();
-  const handlePrevious = () => spotifyPlayerManager.player?.previousTrack();
+
+  // Queue-aware next/previous handlers
+  const handleNext = async () => {
+    const nextTrack = usePlayerStore.getState().nextTrack();
+
+    if (nextTrack && deviceId) {
+      // Play the next track from our queue
+      try {
+        const response = await fetch("/api/spotify/play", {
+          method: "PUT",
+          headers: {
+            "Content-type": "application/json",
+          },
+          body: JSON.stringify({
+            trackUri: nextTrack.uri || `spotify:track:${nextTrack.id}`,
+            deviceId: deviceId,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to play next track");
+        }
+      } catch (error) {
+        console.error("Error playing next track:", error);
+      }
+    } else {
+      // No more tracks in queue
+      console.log("End of queue reached");
+    }
+  };
+
+  const handlePrevious = async () => {
+    const prevTrack = usePlayerStore.getState().previousTrack();
+
+    if (prevTrack && deviceId) {
+      // Play the previous track from our queue
+      try {
+        const response = await fetch("/api/spotify/play", {
+          method: "PUT",
+          headers: {
+            "Content-type": "application/json",
+          },
+          body: JSON.stringify({
+            trackUri: prevTrack.uri || `spotify:track:${prevTrack.id}`,
+            deviceId: deviceId,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error("Failed to play previous track");
+        }
+      } catch (error) {
+        console.error("Error playing previous track:", error);
+      }
+    } else {
+      // No previous tracks in queue
+      console.log("Beginning of queue reached");
+    }
+  };
 
   const handleSeek = (percentage: number) => {
     if (spotifyPlayerManager.player && duration > 0) {

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -113,10 +113,19 @@ export interface TrackInfoProps {
   playlistId?: string;
   deleteTrack?: (spotifyId: string) => void;
   showPlayButton?: boolean;
+
+  //queue context props
+  allTracks?: SpotifyTrack[];
+  trackIndex?: number;
+  playbackContext?: string;
 }
 
 export interface TrackCardProps {
   track: SpotifyTrack;
+  //queue context props
+  allTracks?: SpotifyTrack[];
+  trackIndex?: number;
+  playbackContext?: string;
 }
 
 //interfaces for the Web Playback SDK


### PR DESCRIPTION
- Add queue management to player store with track array and current index
- Update TrackCard and TrackInfo components to support queue context
- Modify API route to handle multiple track URIs with offset positioning
- Enable next/previous buttons to work with local queue instead of relying on Spotify context
- Add playback context tracking (dashboard, liked, playlist, search)