### PR TITLE
feat: extend queue system to all track contexts

### DIFF
--- a/src/app/likedtracks/page.tsx
+++ b/src/app/likedtracks/page.tsx
@@ -44,10 +44,13 @@ const LikedTracks = () => {
 
       {!isLoading && likedTracks.length > 0 && (
         <div>
-          {likedTracks.map((track) => (
+          {likedTracks.map((track, index) => (
             <TrackInfo
               key={track.id}
               track={track}
+              allTracks={likedTracks}
+              trackIndex={index}
+              playbackContext="liked"
               showLikeButton={false}
               showPlayButton={true}
             />

--- a/src/app/playlists/[id]/page.tsx
+++ b/src/app/playlists/[id]/page.tsx
@@ -48,10 +48,13 @@ const CustomPlaylistTracks = () => {
       {isLoading && <Loader2 className="h-8 w-8 animate-spin" />}
       {!isLoading && playlistTracks.length > 0 && (
         <div>
-          {playlistTracks.map((track) => (
+          {playlistTracks.map((track, index) => (
             <TrackInfo
               key={track.id}
               track={track}
+              allTracks={playlistTracks}
+              trackIndex={index}
+              playbackContext={`playlist:${playlistId}`}
               showLikeButton={false}
               showRemoveButton={true}
               playlistId={playlistId as string}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -53,10 +53,13 @@ const Search = () => {
 
       {!isLoading && tracks.length > 0 && (
         <div>
-          {tracks.map((track) => (
+          {tracks.map((track, index) => (
             <TrackInfo
               key={track.id}
               track={track}
+              allTracks={tracks}
+              trackIndex={index}
+              playbackContext="search"
               showAddToPlaylist={true}
               showPlayButton={true}
             />


### PR DESCRIPTION
- Add queue support to liked tracks page with "liked" context
- Implement queue for playlist pages with dynamic "playlist:${id}" context
- Enable queue system for search results with "search" context
- All pages now pass allTracks, trackIndex, and playbackContext to TrackInfo
- Next/previous controls now work across dashboard, liked, playlists, and search