### PR TITLE
fix: stop music playback on logout

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -20,6 +20,7 @@ import { Button } from "./ui/button";
 import { useSession } from "next-auth/react";
 import NextImage from "next/image";
 import { useRouter } from "next/navigation";
+import spotifyPlayerManager from "@/lib/spotifyPlayerManager";
 
 const sidebarMenuItems = [
   {
@@ -49,6 +50,17 @@ export function AppSidebar() {
   const router = useRouter();
 
   const handleLogout = async () => {
+    // Stop playback BEFORE logging out (while we still have authentication)
+    if (spotifyPlayerManager.player) {
+      try {
+        await spotifyPlayerManager.player.pause();
+      } catch (error) {
+        console.error("Error pausing playback:", error);
+      }
+      spotifyPlayerManager.disconnect();
+    }
+
+    // Then logout
     await signOut({ redirect: false });
     router.push("/");
   };

--- a/src/components/GlobalPlayer.tsx
+++ b/src/components/GlobalPlayer.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { useSession } from "next-auth/react";
 import WebPlaybackPlayer from "./WebPlaybackPlayer";
 
 const GlobalPlayer = () => {
+  const { data: session } = useSession();
+  //only render music player if user is logged in
+  if (!session) {
+    return;
+  }
+
   return <WebPlaybackPlayer />;
 };
 

--- a/src/lib/spotifyPlayerManager.js
+++ b/src/lib/spotifyPlayerManager.js
@@ -91,8 +91,16 @@ class SpotifyPlayerManager {
   /**
    * Clean up the player when no longer needed
    */
-  disconnect() {
+  async disconnect() {
     if (this.player) {
+      try {
+        // Wait for pause to complete before disconnecting
+        await this.player.pause();
+      } catch (error) {
+        console.error("Error pausing player:", error);
+      }
+
+      // Then disconnect
       this.player.disconnect();
       this.player = null;
       this.deviceId = null;


### PR DESCRIPTION
- Add pre-logout handler in AppSidebar to pause playback before session ends
- Pause player while authentication token is still valid
- Disconnect player before destroying session
- Prevents music from continuing to play after logout
- Remove redundant useEffect cleanup from WebPlaybackPlayer