### PR TITLE
refactor: redesign all cards to vertical Spotify-style layout

### DIFF
--- a/src/app/(protected)/likedtracks/page.tsx
+++ b/src/app/(protected)/likedtracks/page.tsx
@@ -55,7 +55,7 @@ const LikedTracks = () => {
       )}
 
       {!isLoading && likedTracks.length > 0 && (
-        <div className="space-y-3 max-w-4xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
           {likedTracks.map((track, index) => (
             <TrackInfo
               key={track.id}
@@ -64,7 +64,6 @@ const LikedTracks = () => {
               trackIndex={index}
               playbackContext="liked"
               showLikeButton={true}
-              showPlayButton={true}
               onUnlike={handleUnlikeTrack}
             />
           ))}

--- a/src/app/(protected)/playlists/[id]/page.tsx
+++ b/src/app/(protected)/playlists/[id]/page.tsx
@@ -62,7 +62,7 @@ const CustomPlaylistTracks = () => {
       )}
 
       {!isLoading && playlistTracks.length > 0 && (
-        <div className="space-y-3 max-w-4xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           {playlistTracks.map((track, index) => (
             <TrackInfo
               key={track.id}
@@ -74,7 +74,6 @@ const CustomPlaylistTracks = () => {
               showRemoveButton={true}
               playlistId={playlistId as string}
               deleteTrack={handleDeletePlaylistTrack}
-              showPlayButton={true}
             />
           ))}
         </div>

--- a/src/app/(protected)/search/page.tsx
+++ b/src/app/(protected)/search/page.tsx
@@ -76,7 +76,7 @@ const Search = () => {
 
       {/* Search results */}
       {!isLoading && tracks.length > 0 && (
-        <div className="space-y-3 max-w-4xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
           {tracks.map((track, index) => (
             <TrackInfo
               key={track.id}
@@ -85,7 +85,6 @@ const Search = () => {
               trackIndex={index}
               playbackContext="search"
               showAddToPlaylist={true}
-              showPlayButton={true}
             />
           ))}
         </div>

--- a/src/components/TopTracks.tsx
+++ b/src/components/TopTracks.tsx
@@ -38,8 +38,8 @@ const TopTracks = () => {
         Your Top Tracks
       </h2>
       {topTracks && Array.isArray(topTracks) ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 max-w-6xl">
-          {topTracks.slice(0, 6).map((track, index) => (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {topTracks.slice(0, 10).map((track, index) => (
             <TrackCard
               key={track.id}
               track={track}

--- a/src/components/TrackCard.tsx
+++ b/src/components/TrackCard.tsx
@@ -1,114 +1,3 @@
-// import { Card, CardContent } from "./ui/card";
-// import Image from "next/image";
-// import { Button } from "./ui/button";
-// import { Play } from "lucide-react";
-// import { usePlayerStore } from "@/lib/stores/playerStore";
-// import { TrackCardProps } from "@/types/spotify";
-
-// const TrackCard = ({
-//   track,
-//   allTracks,
-//   trackIndex,
-//   playbackContext,
-// }: TrackCardProps) => {
-//   const { deviceId } = usePlayerStore();
-
-//   //get album artwork
-//   const imageUrl =
-//     track.album.images && track.album.images.length > 0
-//       ? track.album.images[0].url
-//       : null;
-
-//   //convert from miliseconds
-//   const formatDuration = (ms: number) => {
-//     const minutes = Math.floor(ms / 60000);
-//     const seconds = Math.floor((ms % 60000) / 1000);
-//     return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-//   };
-
-//   //join multiple artists names
-//   const artistNames = track.artists.map((artist) => artist.name).join(", ");
-
-//   const handlePlayTrack = async () => {
-//     if (!deviceId) {
-//       console.error("No device ID available");
-//       return;
-//     }
-
-//     // If we have queue context, set it up
-//     if (allTracks && trackIndex !== undefined && playbackContext) {
-//       // Set the queue in our store
-//       usePlayerStore
-//         .getState()
-//         .setQueue(allTracks, trackIndex, playbackContext);
-//     }
-
-//     try {
-//       const response = await fetch("/api/spotify/play", {
-//         method: "PUT",
-//         headers: {
-//           "Content-Type": "application/json",
-//         },
-//         body: JSON.stringify({
-//           // If we have a queue, send all track URIs
-//           ...(allTracks && trackIndex !== undefined
-//             ? {
-//                 trackUris: allTracks.map(
-//                   (t) => t.uri || `spotify:track:${t.id}`
-//                 ),
-//                 offset: trackIndex, // Start at this track
-//               }
-//             : {
-//                 // FALLBACK: Single track (old behavior)
-//                 trackUri: track.uri || `spotify:track:${track.id}`,
-//               }),
-//           deviceId: deviceId,
-//         }),
-//       });
-
-//       if (!response.ok) {
-//         throw new Error("Failed to play track");
-//       }
-//     } catch (error) {
-//       console.error("Error playing track:", error);
-//     }
-//   };
-
-//   return (
-//     <Card className="mb-4">
-//       <CardContent className="flex items-center p-4">
-//         {/* Album artwork */}
-//         {imageUrl ? (
-//           <Image
-//             src={imageUrl}
-//             alt={track.album.name}
-//             className="rounded-md mr-4 object-cover"
-//             width={64}
-//             height={64}
-//           />
-//         ) : (
-//           <div className="w-16 h-16 bg-gray-300 rounded-md mr-4 flex items-center justify-center">
-//             <span className="text-gray-500 text-xs">No Image</span>
-//           </div>
-//         )}
-
-//         {/* Track info */}
-//         <div className="flex-1">
-//           <h3 className="font-semibold text-lg">{track.name}</h3>
-//           <p className="text-sm text-gray-600">{artistNames}</p>
-//           <p className="text-sm text-gray-500">
-//             {formatDuration(track.duration_ms)}
-//           </p>
-//         </div>
-//         <Button onClick={handlePlayTrack} variant="outline" size="sm">
-//           <Play className="h-4 w-4" />
-//         </Button>
-//       </CardContent>
-//     </Card>
-//   );
-// };
-
-// export default TrackCard;
 import { Card, CardContent } from "./ui/card";
 import Image from "next/image";
 import { Button } from "./ui/button";
@@ -128,12 +17,6 @@ const TrackCard = ({
     track.album.images && track.album.images.length > 0
       ? track.album.images[0].url
       : null;
-
-  const formatDuration = (ms: number) => {
-    const minutes = Math.floor(ms / 60000);
-    const seconds = Math.floor((ms % 60000) / 1000);
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-  };
 
   const artistNames = track.artists.map((artist) => artist.name).join(", ");
 
@@ -179,45 +62,42 @@ const TrackCard = ({
   };
 
   return (
-    <Card className="group hover:shadow-lg transition-shadow duration-200 border-gray-200 hover:border-purple-300">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
-          {/* Album artwork */}
+    <Card className="group hover:shadow-xl transition-all duration-200 border-gray-200 hover:border-purple-300 overflow-hidden">
+      <CardContent className="p-0">
+        {/* Album artwork - full width at top */}
+        <div className="relative aspect-square w-full overflow-hidden">
           {imageUrl ? (
-            <div className="relative flex-shrink-0">
+            <>
               <Image
                 src={imageUrl}
                 alt={track.album.name}
-                className="rounded-md object-cover"
-                width={80}
-                height={80}
+                className="object-cover"
+                width={300}
+                height={300}
               />
-              <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity rounded-md flex items-center justify-center">
+              <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
                 <Button
                   onClick={handlePlayTrack}
                   size="icon"
-                  className="bg-purple-600 hover:bg-purple-700 text-white rounded-full h-10 w-10"
+                  className="bg-purple-600 hover:bg-purple-700 text-white rounded-full h-14 w-14 shadow-lg"
                 >
-                  <Play className="h-5 w-5 fill-white" />
+                  <Play className="h-6 w-6 fill-white ml-1" />
                 </Button>
               </div>
-            </div>
+            </>
           ) : (
-            <div className="w-20 h-20 bg-gray-200 rounded-md flex-shrink-0 flex items-center justify-center">
-              <span className="text-gray-400 text-xs">No Image</span>
+            <div className="w-full h-full bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center">
+              <span className="text-gray-400">No Image</span>
             </div>
           )}
+        </div>
 
-          {/* Track info */}
-          <div className="flex-1 min-w-0">
-            <h3 className="font-semibold text-base text-gray-900 truncate group-hover:text-purple-700 transition-colors">
-              {track.name}
-            </h3>
-            <p className="text-sm text-gray-600 truncate">{artistNames}</p>
-            <p className="text-xs text-gray-500 mt-1">
-              {formatDuration(track.duration_ms)}
-            </p>
-          </div>
+        {/* Track info - below image */}
+        <div className="p-4">
+          <h3 className="font-semibold text-base text-gray-900 truncate group-hover:text-purple-700 transition-colors mb-1">
+            {track.name}
+          </h3>
+          <p className="text-sm text-gray-600 truncate">{artistNames}</p>
         </div>
       </CardContent>
     </Card>

--- a/src/components/TrackInfo.tsx
+++ b/src/components/TrackInfo.tsx
@@ -19,7 +19,6 @@ const TrackInfo = ({
   showLikeButton = true,
   showAddToPlaylist = false,
   showRemoveButton = false,
-  showPlayButton = false,
   playlistId,
   deleteTrack,
   allTracks,
@@ -219,60 +218,58 @@ const TrackInfo = ({
     }
   };
 
-  //convert from miliseconds
-  const formatDuration = (ms: number) => {
-    const minutes = Math.floor(ms / 60000);
-    const seconds = Math.floor((ms % 60000) / 1000);
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-  };
-
   return (
-    <Card className="group hover:shadow-lg transition-all duration-200 border-gray-200 hover:border-purple-300">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
-          {/* Album artwork */}
+    <Card className="group hover:shadow-xl transition-all duration-200 border-gray-200 hover:border-purple-300 overflow-hidden">
+      <CardContent className="p-0">
+        {/* Album artwork - full width at top */}
+        <div className="relative aspect-square">
           {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={track.album.name}
-              className="rounded-md object-cover flex-shrink-0"
-              width={64}
-              height={64}
-            />
+            <>
+              <Image
+                src={imageUrl}
+                alt={track.album.name}
+                className="object-cover w-full h-full"
+                width={300}
+                height={300}
+              />
+              <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                <Button
+                  onClick={handlePlayTrack}
+                  size="icon"
+                  className="bg-purple-600 hover:bg-purple-700 text-white rounded-full h-14 w-14 shadow-lg"
+                >
+                  <Play className="h-6 w-6 fill-white ml-1" />
+                </Button>
+              </div>
+            </>
           ) : (
-            <div className="w-16 h-16 bg-gray-200 rounded-md flex-shrink-0 flex items-center justify-center">
-              <span className="text-gray-400 text-xs">No Image</span>
+            <div className="w-full aspect-square bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center">
+              <span className="text-gray-400">No Image</span>
             </div>
           )}
+        </div>
 
-          {/* Track info */}
-          <div className="flex-1 min-w-0">
-            <h3 className="font-semibold text-base text-gray-900 truncate">
-              {track.name}
-            </h3>
-            <p className="text-sm text-gray-600 truncate">{artistNames}</p>
-            <p className="text-xs text-gray-500 truncate">{track.album.name}</p>
-            <p className="text-xs text-gray-500 mt-1">
-              {formatDuration(track.duration_ms)}
-            </p>
-          </div>
+        {/* Track info - below image */}
+        <div className="p-4">
+          <h3 className="font-semibold text-base text-gray-900 truncate group-hover:text-purple-700 transition-colors mb-1">
+            {track.name}
+          </h3>
+          <p className="text-sm text-gray-600 truncate mb-1">{artistNames}</p>
+          <p className="text-xs text-gray-500 truncate">{track.album.name}</p>
 
-          {/* Action buttons */}
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {showPlayButton && (
-              <Button
-                onClick={handlePlayTrack}
-                size="sm"
-                className="bg-purple-600 hover:bg-purple-700 text-white"
-              >
-                <Play className="h-4 w-4" />
-              </Button>
-            )}
-
+          {/* Action buttons - horizontal row at bottom */}
+          <div className="flex items-center gap-2 mt-3 pt-3 border-t border-gray-100">
             {showLikeButton && (
-              <Button onClick={handleToggleLike} variant="ghost" size="sm">
+              <Button
+                onClick={handleToggleLike}
+                variant="ghost"
+                size="sm"
+                className="flex-shrink-0"
+              >
                 <Heart
-                  className={liked ? "text-red-500" : "text-gray-400"}
+                  className={`h-4 w-4 ${
+                    liked ? "text-red-500" : "text-gray-400"
+                  }`}
                   fill={liked ? "red" : "none"}
                 />
               </Button>
@@ -290,7 +287,7 @@ const TrackInfo = ({
                   <Button
                     variant="outline"
                     size="sm"
-                    className="hover:bg-purple-50"
+                    className="flex-1 text-xs hover:bg-purple-50"
                   >
                     Add to Playlist
                   </Button>
@@ -309,8 +306,13 @@ const TrackInfo = ({
             )}
 
             {showRemoveButton && (
-              <Button size="sm" onClick={handleDelete} variant="destructive">
-                Delete
+              <Button
+                size="sm"
+                onClick={handleDelete}
+                variant="destructive"
+                className="flex-1 text-xs"
+              >
+                Remove
               </Button>
             )}
           </div>

--- a/src/components/playlist/CustomPlaylistCard.tsx
+++ b/src/components/playlist/CustomPlaylistCard.tsx
@@ -94,79 +94,83 @@ const CustomPlaylistCard = ({
   const formatCreatedAt = () => {
     const date = new Date(playlist.createdAt);
     return date.toLocaleDateString("en-US", {
-      month: "long",
+      month: "short",
       day: "numeric",
       year: "numeric",
     });
   };
 
   return (
-    <Card className="group hover:shadow-lg transition-all duration-200 border-gray-200 hover:border-purple-300">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
-          {/* Playlist image */}
+    <Card className="group hover:shadow-xl transition-all duration-200 border-gray-200 hover:border-purple-300 overflow-hidden">
+      <CardContent className="p-0">
+        {/* Playlist image - full width at top */}
+        <div
+          className="relative aspect-square w-full cursor-pointer overflow-hidden"
+          onClick={!isEditing ? handleView : undefined}
+        >
           {playlist.imageUrl ? (
             <Image
               src={playlist.imageUrl}
               alt={playlist.name}
-              className="rounded-md object-cover flex-shrink-0"
-              width={80}
-              height={80}
+              className="object-cover"
+              width={300}
+              height={300}
             />
           ) : (
-            <div className="w-20 h-20 bg-gradient-to-br from-purple-100 to-purple-200 rounded-md flex-shrink-0 flex items-center justify-center">
-              <Music2 className="h-8 w-8 text-purple-600" />
+            <div className="w-full h-full bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center">
+              <Music2 className="h-16 w-16 text-purple-600" />
             </div>
           )}
+        </div>
 
-          {/* Playlist info */}
-          <div className="flex-1 min-w-0">
-            {isEditing ? (
-              <Input
-                type="text"
-                value={editName}
-                onChange={handleNameChange}
-                className="mb-2 border-purple-300 focus:border-purple-500"
-              />
-            ) : (
-              <h3 className="font-semibold text-lg text-gray-900 truncate mb-1">
-                {playlist.name}
-              </h3>
-            )}
+        {/* Playlist info - below image */}
+        <div className="p-4">
+          {isEditing ? (
+            <Input
+              type="text"
+              value={editName}
+              onChange={handleNameChange}
+              className="mb-2 border-purple-300 focus:border-purple-500"
+            />
+          ) : (
+            <h3 className="font-semibold text-base text-gray-900 truncate group-hover:text-purple-700 transition-colors mb-1">
+              {playlist.name}
+            </h3>
+          )}
 
-            {playlist.description && (
-              <p className="text-gray-600 text-sm mb-2 line-clamp-2">
-                {playlist.description}
-              </p>
-            )}
+          {playlist.description && (
+            <p className="text-sm text-gray-600 truncate mb-1">
+              {playlist.description}
+            </p>
+          )}
 
-            <div className="flex items-center gap-3 text-xs text-gray-500">
-              <span>{playlist._count?.PlaylistTrack || 0} tracks</span>
-              <span>•</span>
-              <span>{formatCreatedAt()}</span>
-              <span>•</span>
-              <span
-                className={
-                  playlist.isPublic ? "text-purple-600 font-medium" : ""
-                }
-              >
-                {playlist.isPublic ? "Public" : "Private"}
-              </span>
-            </div>
+          <div className="flex flex-col gap-1 text-xs text-gray-500 mb-2">
+            <span>{playlist._count?.PlaylistTrack || 0} tracks</span>
+            <span>{formatCreatedAt()}</span>
+            <span
+              className={playlist.isPublic ? "text-purple-600 font-medium" : ""}
+            >
+              {playlist.isPublic ? "Public" : "Private"}
+            </span>
           </div>
 
-          {/* Action buttons */}
-          <div className="flex items-center gap-2 flex-shrink-0">
+          {/* Action buttons - at bottom */}
+          <div className="flex flex-col gap-4 mt-3 pt-3 border-t border-gray-100">
             {isEditing ? (
               <>
                 <Button
                   size="sm"
                   onClick={handleSave}
-                  className="bg-purple-600 hover:bg-purple-700"
+                  className="bg-purple-600 hover:bg-purple-700 w-full text-xs"
                 >
                   Save
                 </Button>
-                <Button size="sm" onClick={handleCancel} variant="outline">
+                <Button
+                  size="sm"
+                  onClick={handleCancel}
+                  variant="outline"
+                  className="w-full text-xs"
+                >
                   Cancel
                 </Button>
               </>
@@ -175,21 +179,28 @@ const CustomPlaylistCard = ({
                 <Button
                   size="sm"
                   onClick={handleView}
-                  className="bg-purple-600 hover:bg-purple-700"
+                  className="bg-purple-600 hover:bg-purple-700 w-full text-xs"
                 >
                   View
                 </Button>
-                <Button
-                  size="sm"
-                  onClick={handleEditMode}
-                  variant="outline"
-                  className="hover:bg-purple-50"
-                >
-                  Edit
-                </Button>
-                <Button size="sm" onClick={handleDelete} variant="destructive">
-                  Delete
-                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    onClick={handleEditMode}
+                    variant="outline"
+                    className="hover:bg-purple-50 flex-1 text-xs"
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleDelete}
+                    variant="destructive"
+                    className="flex-1 text-xs"
+                  >
+                    Delete
+                  </Button>
+                </div>
               </>
             )}
           </div>

--- a/src/components/playlist/DisplayPlaylists.tsx
+++ b/src/components/playlist/DisplayPlaylists.tsx
@@ -7,16 +7,18 @@ const DisplayPlaylists = ({
   onPlaylistUpdate,
 }: DisplayPlaylistsProps) => {
   return (
-    <div className="space-y-4 max-w-4xl mx-auto">
+    <div>
       {playlists.length > 0 ? (
-        playlists.map((playlist) => (
-          <CustomPlaylistCard
-            key={playlist.id}
-            playlist={playlist}
-            onPlaylistDelete={onPlaylistDelete}
-            onPlaylistUpdate={onPlaylistUpdate}
-          />
-        ))
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {playlists.map((playlist) => (
+            <CustomPlaylistCard
+              key={playlist.id}
+              playlist={playlist}
+              onPlaylistDelete={onPlaylistDelete}
+              onPlaylistUpdate={onPlaylistUpdate}
+            />
+          ))}
+        </div>
       ) : (
         <p className="text-gray-500 text-center py-8">
           No playlists yet. Create your first one above!

--- a/src/components/playlist/Playlists.tsx
+++ b/src/components/playlist/Playlists.tsx
@@ -33,8 +33,8 @@ const Playlists = () => {
         Your Spotify Playlists
       </h2>
       {playlists && Array.isArray(playlists) ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 max-w-6xl">
-          {playlists.slice(0, 6).map((playlist) => (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+          {playlists.slice(0, 10).map((playlist) => (
             <PlaylistCard key={playlist.id} playlist={playlist} />
           ))}
         </div>

--- a/src/components/playlist/SpotifyPlaylistCard.tsx
+++ b/src/components/playlist/SpotifyPlaylistCard.tsx
@@ -19,44 +19,43 @@ const SpotifyPlaylistCard = ({ playlist }: PlaylistCardProps) => {
       href={`https://open.spotify.com/playlist/${playlist.id}`}
       target="_blank"
     >
-      <Card className="group hover:shadow-lg transition-all duration-200 border-gray-200 hover:border-purple-300 cursor-pointer h-full">
-        <CardContent className="p-4">
-          <div className="flex items-start gap-4">
-            {/* Playlist image */}
+      <Card className="group hover:shadow-xl transition-all duration-200 border-gray-200 hover:border-purple-300 cursor-pointer overflow-hidden">
+        <CardContent className="p-0">
+          {/* Playlist image - full width at top */}
+          <div className="relative aspect-square w-full overflow-hidden">
             {imageUrl ? (
-              <div className="relative flex-shrink-0">
-                <Image
-                  src={imageUrl}
-                  alt={playlist.name}
-                  className="rounded-md object-cover"
-                  width={80}
-                  height={80}
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity rounded-md" />
-              </div>
+              <Image
+                src={imageUrl}
+                alt={playlist.name}
+                className="object-cover"
+                width={300}
+                height={300}
+              />
             ) : (
-              <div className="w-20 h-20 bg-gradient-to-br from-purple-100 to-purple-200 rounded-md flex-shrink-0 flex items-center justify-center">
-                <Music2 className="h-8 w-8 text-purple-600" />
+              <div className="w-full h-full bg-gradient-to-br from-purple-100 to-purple-200 flex items-center justify-center">
+                <Music2 className="h-16 w-16 text-purple-600" />
               </div>
             )}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
+          </div>
 
-            {/* Playlist info */}
-            <div className="flex-1 min-w-0">
-              <h3 className="font-semibold text-base text-gray-900 truncate group-hover:text-purple-700 transition-colors mb-1">
-                {playlist.name}
-              </h3>
-
-              <p className="text-sm text-purple-600 font-medium mb-2">
-                {playlist.tracks.total}{" "}
-                {playlist.tracks.total === 1 ? "track" : "tracks"}
+          {/* Playlist info - below image */}
+          <div className="p-4 h-32">
+            {" "}
+            {/* Fixed height */}
+            <h3 className="font-semibold text-base text-gray-900 truncate group-hover:text-purple-700 transition-colors mb-1">
+              {playlist.name}
+            </h3>
+            <p className="text-sm text-purple-600 font-medium mb-2">
+              {playlist.tracks.total}{" "}
+              {playlist.tracks.total === 1 ? "track" : "tracks"}
+            </p>
+            {playlist.description && (
+              <p className="text-xs text-gray-500 line-clamp-3">
+                {" "}
+                {playlist.description}
               </p>
-
-              {playlist.description && (
-                <p className="text-xs text-gray-500 line-clamp-2">
-                  {playlist.description}
-                </p>
-              )}
-            </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -112,7 +112,6 @@ export interface TrackInfoProps {
   showRemoveButton?: boolean;
   playlistId?: string;
   deleteTrack?: (spotifyId: string) => void;
-  showPlayButton?: boolean;
   onUnlike?: (spotifyId: string) => void;
 
   //queue context props


### PR DESCRIPTION
- Convert TrackInfo, CustomPlaylistCard, SpotifyPlaylistCard, and TrackCard to vertical card design
- Replace horizontal layouts with image-on-top, info-below structure
- Update all page wrappers to use responsive grid layouts (2-5 columns)
- Add hover play button overlay on album artwork
- Fix card height inconsistencies with fixed-height text containers
- Remove deprecated showPlayButton prop from TrackInfo
- Improve visual consistency across dashboard, playlists, search, and liked tracks pages